### PR TITLE
typo

### DIFF
--- a/editorconfig.go
+++ b/editorconfig.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2019, Daniel Martí <mvdan@mvdan.cc>
 // See LICENSE for licensing information
 
-// Pakage editorconfig allows parsing and using EditorConfig files, as defined
+// Package editorconfig allows parsing and using EditorConfig files, as defined
 // in https://editorconfig.org/.
 package editorconfig
 


### PR DESCRIPTION
The lintian tool will trigger this typo so maybe you could consider creating a new tag with this fix and it will also resolve this other typo: https://github.com/mvdan/editorconfig/blob/f20b0a5c020a1908c6c5ad0ebfba419c2f679145/editorconfig.go#L148

`editorconfig.go:148: underyling ==> underlying`